### PR TITLE
Update events to send webhooks on order status change

### DIFF
--- a/PicqerOrderPusher.php
+++ b/PicqerOrderPusher.php
@@ -16,6 +16,8 @@ class PicqerOrderPusher extends Plugin
     {
         return [
             'sOrder::sSaveOrder::after' => 'pushOrder',
+            'sOrder::setPaymentStatus::after' => 'pushOrder',
+            'sOrder::setOrderStatus::after' => 'pushOrder',
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "picqer/shopware-plugin",
   "description": "Picqer Extended Integration for Shopware",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "type": "shopware-plugin",
   "extra": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
     <label lang="de">Picqer</label>
     <label lang="nl">Picqer</label>
 
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <copyright>(c) Picqer</copyright>
     <author>Picqer</author>
     <link>https://picqer.com</link>


### PR DESCRIPTION
Currently only webhooks are send when order is initially saved. This can cause delays in processing the payment of orders.

There is no general event to get updates about change in orders. So I used `setPaymentStatus` and `setOrderStatus` method events to get updates when the state of an order or payment changes.