### PR TITLE
Fix: plugin is broken on 5.7.3 due to ServiceNotFoundException

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <service id="picqer_order_pusher.config" class="PicqerOrderPusher\Components\Config">
+        <service id="picqer_order_pusher.config" class="PicqerOrderPusher\Components\Config" public="true">
             <argument type="service" id="shopware.plugin.cached_config_reader" />
         </service>
 


### PR DESCRIPTION
[Basecamp](https://3.basecamp.com/3093964/buckets/13275618/todos/4233184005)

The plugin is broken on version 5.7.3 of Shopware and probably on other versions of 5.7.*. After placing an order, the log registered the following Exception:

`core.ERROR: Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The "picqer_order_pusher.config" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead. in /var/www/html/vendor/symfony/dependency-injection/Container.php:275`

This was triggered by:
https://github.com/picqer/shopware-plugin/blob/72714501b75b03404510e3cac31a7caa7907dd28/PicqerOrderPusher.php#L65


A quick search learned that Shopware is now using the symfony version where services in the symfony container are private by default now. This fix makes the service in the plugin public again.